### PR TITLE
os.path.join instead of "/"

### DIFF
--- a/test/integ/h5tojson_test.py
+++ b/test/integ/h5tojson_test.py
@@ -20,13 +20,13 @@ from shutil import copyfile
 """
 main
 """
-top_dir = os.path.abspath("../..")
+top_dir = os.path.abspath(os.path.join("..",".."))
 
-data_dir = os.path.join(top_dir, "data/hdf5")
+data_dir = os.path.join(top_dir, "data","hdf5")
 
 util_dir = os.path.join(top_dir, "util")
 
-out_dir = os.path.join(top_dir, "test/integ/json_out")
+out_dir = os.path.join(top_dir, "test","integ","json_out")
 
 test_files = (
     "array_dset.h5",


### PR DESCRIPTION
Tests are non-functional on Windows as is, making updates to correct this.