### PR TITLE
Removed 'pwd'

### DIFF
--- a/test/testall.py
+++ b/test/testall.py
@@ -27,7 +27,6 @@ for file_name in unit_tests:
         sys.exit("Failed")
 
 os.chdir('../integ')
-os.system('pwd')
 for file_name in integ_tests:
     print(file_name)
     rc = os.system('python ' + file_name + '.py')


### PR DESCRIPTION
Pwd does not run on Windows. Removed, unneeded for tests.