### PR TITLE
Do not install test modules

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
 
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
-    packages=find_packages(exclude=['docs', 'test']),
+    packages=find_packages(exclude=['docs', 'test*']),
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
`find_packages` requires a glob, otherwise it installs submodules:

```
>>> from setuptools import find_packages
>>> print(find_packages(exclude=['docs', 'test']))
['h5json', 'test.unit', 'test.integ']
>>> print(find_packages(exclude=['docs', 'test*']))
['h5json']
```