### PR TITLE
Feature/h5raw hash to array

### DIFF
--- a/h5json/utils/create_frames_array.py
+++ b/h5json/utils/create_frames_array.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import sys
+import json
+
+
+def main():
+
+    frames = []
+
+    for arg in sys.argv[1:]:
+        with open(arg, encoding='utf-8') as f:
+            data = json.loads(f.read())
+            frames.append(data)
+
+    print(json.dumps(frames))
+
+if __name__ == "__main__":
+    main()
+

--- a/h5tojson/h5tojson.py
+++ b/h5tojson/h5tojson.py
@@ -119,7 +119,7 @@ class DumpJson:
     def dumpDataset(self, uuid):
         response = { }
         self.log.info("dumpDataset: " + uuid)
-        item = self.db.getDatasetItemByUuid(uuid) #HAVE TO FIND WHERE THE ITEM HASHTABLE GETS CONSTRUCTED to determine the TYPE
+        item = self.db.getDatasetItemByUuid(uuid)
 
         if 'alias' in item:
             alias = item['alias']
@@ -189,19 +189,6 @@ class DumpJson:
             response['attributes'] = attributes
 
         return response
-
-
-
-    # def dumpDatatypes(self):
-    #     uuids = self.db.getCollection("datatypes")
-    #     if uuids:
-    #         datatypes = {}
-    #         for uuid in uuids:
-    #             item = self.dumpDatatype(uuid)
-    #             datatypes[uuid] = item
-    #
-    #         self.json['datatypes'] = datatypes
-
 
     def dumpDatatypes(self):
         uuids = self.db.getCollection("datatypes")

--- a/h5tojson/h5tojson.py
+++ b/h5tojson/h5tojson.py
@@ -97,13 +97,21 @@ class DumpJson:
 
 
     def dumpGroups(self):
-        groups = {}
+        groups = []
         item = self.dumpGroup(self.root_uuid)
-        groups[self.root_uuid] = item
+
+        root_group = {"id": self.root_uuid}
+        root_group.update(item)
+        groups.append(root_group)
+
         uuids = self.db.getCollection("groups")
+
         for uuid in uuids:
             item = self.dumpGroup(uuid)
-            groups[uuid] = item
+
+            group = {"id": uuid}
+            group.update(item)
+            groups.append(group)
 
         self.json['groups'] = groups
 
@@ -111,7 +119,8 @@ class DumpJson:
     def dumpDataset(self, uuid):
         response = { }
         self.log.info("dumpDataset: " + uuid)
-        item = self.db.getDatasetItemByUuid(uuid)
+        item = self.db.getDatasetItemByUuid(uuid) #HAVE TO FIND WHERE THE ITEM HASHTABLE GETS CONSTRUCTED to determine the TYPE
+
         if 'alias' in item:
             alias = item['alias']
             if alias:
@@ -124,10 +133,12 @@ class DumpJson:
         shape_rsp = {}
         num_elements = 1
         shape_rsp['class'] = shapeItem['class']
+
         if 'dims' in shapeItem:
             shape_rsp['dims'] = shapeItem['dims']
             for dim in shapeItem['dims']:
                 num_elements *= dim
+
         if 'maxdims' in shapeItem:
             maxdims = []
             for dim in shapeItem['maxdims']:
@@ -156,11 +167,14 @@ class DumpJson:
 
     def dumpDatasets(self):
         uuids = self.db.getCollection("datasets")
+
         if uuids:
-            datasets = {}
+            datasets = []
             for uuid in uuids:
                 item = self.dumpDataset(uuid)
-                datasets[uuid] = item
+                dataset = {"id": uuid}
+                dataset.update(item)
+                datasets.append(dataset)
 
             self.json['datasets'] = datasets
 
@@ -173,16 +187,33 @@ class DumpJson:
         attributes = self.dumpAttributes('datatypes', uuid)
         if attributes:
             response['attributes'] = attributes
+
         return response
+
+
+
+    # def dumpDatatypes(self):
+    #     uuids = self.db.getCollection("datatypes")
+    #     if uuids:
+    #         datatypes = {}
+    #         for uuid in uuids:
+    #             item = self.dumpDatatype(uuid)
+    #             datatypes[uuid] = item
+    #
+    #         self.json['datatypes'] = datatypes
 
 
     def dumpDatatypes(self):
         uuids = self.db.getCollection("datatypes")
+
         if uuids:
-            datatypes = {}
+            datatypes = []
             for uuid in uuids:
                 item = self.dumpDatatype(uuid)
-                datatypes[uuid] = item
+                datatype = {"id": uuid}
+                datatype.update(item)
+
+                datatypes.append(datatype)
 
             self.json['datatypes'] = datatypes
 


### PR DESCRIPTION
Changes based on updated grammar for HDF5-to-JSON conversion:

1) `groups`, `datatypes`, and `datasets` are arrays instead of hashtables
2) instead of `uuid: { ... }` each has `{"id": uuid}` instead
3) Committed datatypes string id removed `datatypes/` and changed to ` { "idref": typeItem['uuid'] }`
4) script for joining json files into array as per RAW requirement