### PR TITLE
Fix getNow() resolution on Windows without an app anchor

### DIFF
--- a/src/h5json/time_util.py
+++ b/src/h5json/time_util.py
@@ -62,6 +62,14 @@ def elapsedTime(timestamp):
     return ret_str
 
 
+# Fallback anchor for getNow() on platforms with a coarse wall clock: a
+# wall-clock reading paired with a monotonic reading taken at the same moment,
+# so later calls can advance the wall clock by a precisely measured delta.
+# Captured once, at import.
+_start_time = time.time()
+_start_time_relative = time.perf_counter()
+
+
 def getNow(app=None):
     """
     Get current time in unix timestamp
@@ -73,13 +81,22 @@ def getNow(app=None):
     current_time = 0
 
     if system == "nt":
-        # Windows
-        if app is None or "start_time_relative" not in app or "start_time" not in app:
-            current_time = time.time()  # just use lower precision time.time()
+        # Windows: before Python 3.13, time.time() only advances once per
+        # ~15.6ms system tick, so objects created in a loop get timestamps that
+        # compare equal. Callers order attributes and links by their "created"
+        # value, and equal timestamps leave that order undefined - so advance a
+        # wall-clock anchor by a perf_counter delta rather than reading the
+        # coarse clock directly. Prefer the caller's anchor when it has one; it
+        # is set once at node startup, so it stays consistent across a process.
+        if app is not None and "start_time_relative" in app and "start_time" in app:
+            start_time = app["start_time"]
+            start_time_relative = app["start_time_relative"]
         else:
-            current_time = (time.perf_counter() - app["start_time_relative"]) + app["start_time"]
+            start_time = _start_time
+            start_time_relative = _start_time_relative
+        current_time = (time.perf_counter() - start_time_relative) + start_time
     elif system == "posix":
-        # Unix
+        # Unix - time.time() is already fine-grained here
         current_time = time.time()
     else:
         raise ValueError(f"Unsupported OS: {system}")

--- a/test/unit/time_util_test.py
+++ b/test/unit/time_util_test.py
@@ -12,8 +12,10 @@
 import unittest
 import logging
 import time
+from unittest import mock
 
-from h5json.time_util import unixTimeToUTC, elapsedTime
+from h5json import time_util
+from h5json.time_util import unixTimeToUTC, elapsedTime, getNow
 
 
 class TimeUtilTest(unittest.TestCase):
@@ -77,6 +79,110 @@ class TimeUtilTest(unittest.TestCase):
         self.assertTrue("hours" in result)
         self.assertTrue("minutes" in result)
         self.assertTrue("seconds" in result)
+
+
+class _FrozenClock:
+    """Stand-in for a wall clock too coarse to separate successive calls.
+
+    Models the pre-3.13 Windows case, where time.time() only advances once per
+    ~15.6ms system tick: every call made inside one tick returns the same
+    value. Returning a constant is that worst case.
+    """
+
+    def __init__(self, value=1700000000.0):
+        self.value = value
+
+    def __call__(self):
+        return self.value
+
+
+class GetNowTest(unittest.TestCase):
+    """Tests for getNow().
+
+    The Windows-specific behavior is exercised by forcing os.name and stubbing
+    the wall clock, rather than by relying on a Windows runner. Two reasons: it
+    then runs on every platform, and a real-clock test would silently pass on
+    Windows/Python 3.13 anyway - 3.13 switched time.time() to
+    GetSystemTimePreciseAsFileTime, so the coarse clock this guards against is
+    only observable on 3.11/3.12.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(GetNowTest, self).__init__(*args, **kwargs)
+        self.logger = logging.getLogger()
+        self.logger.setLevel(logging.WARNING)
+
+    def testGetNowResolvesSubTickIntervals(self):
+        # objects are ordered by their "created" timestamp, so timestamps that
+        # compare equal leave creation order undefined. Spin for an interval far
+        # shorter than the ~15.6ms coarse tick but far longer than any
+        # platform's monotonic-clock resolution, then require that getNow()
+        # noticed. Deliberately not "call it N times and count distinct
+        # values": that measures loop speed against perf_counter resolution,
+        # which varies by platform, where this measures the property at issue.
+        with mock.patch.object(time_util.os, "name", "nt"):
+            with mock.patch.object(time_util.time, "time", _FrozenClock()):
+                before = getNow()
+                deadline = time.perf_counter() + 0.001  # 1ms
+                while time.perf_counter() < deadline:
+                    pass
+                after = getNow()
+
+        self.assertGreater(after, before)
+
+    def testGetNowIsMonotonicOnCoarseClock(self):
+        # a batch taken back-to-back must never go backwards, whatever the
+        # underlying clock resolution turns out to be
+        count = 200
+        with mock.patch.object(time_util.os, "name", "nt"):
+            with mock.patch.object(time_util.time, "time", _FrozenClock()):
+                values = [getNow() for _ in range(count)]
+
+        self.assertEqual(len(values), count)
+        self.assertEqual(values, sorted(values))
+        # reading the coarse clock directly collapses this to exactly 1; the
+        # bound stays well clear of how many ties a fast loop may produce on
+        # platforms with a coarser monotonic clock (macOS runners hit ~50%)
+        self.assertGreaterEqual(len(set(values)), count // 10)
+
+    def testGetNowPrefersAppAnchor(self):
+        # a caller-supplied anchor is used in preference to the module one
+        app = {"start_time": 1000000.0, "start_time_relative": time.perf_counter()}
+        with mock.patch.object(time_util.os, "name", "nt"):
+            with mock.patch.object(time_util.time, "time", _FrozenClock()):
+                now = getNow(app)
+        # elapsed since the anchor was taken is small, so the result should sit
+        # just after the anchor's start_time - not at the frozen clock's value
+        self.assertGreaterEqual(now, app["start_time"])
+        self.assertLess(now, app["start_time"] + 60)
+
+    def testGetNowIgnoresIncompleteAppAnchor(self):
+        # a dict missing either key must not be used as an anchor - it has to
+        # fall back to the module anchor, not to the coarse clock
+        for app in ({}, {"start_time": 1000000.0}, {"start_time_relative": 0.0}):
+            with mock.patch.object(time_util.os, "name", "nt"):
+                with mock.patch.object(time_util.time, "time", _FrozenClock()):
+                    before = getNow(app)
+                    deadline = time.perf_counter() + 0.001
+                    while time.perf_counter() < deadline:
+                        pass
+                    after = getNow(app)
+            self.assertGreater(after, before, f"app: {app}")
+
+    def testGetNowTracksWallClock(self):
+        # on the real platform, getNow() should agree with the wall clock;
+        # guards the anchor being mis-derived rather than merely fine-grained
+        self.assertAlmostEqual(getNow(), time.time(), delta=5)
+
+    def testGetNowPosixUsesWallClock(self):
+        frozen = _FrozenClock()
+        with mock.patch.object(time_util.os, "name", "posix"):
+            with mock.patch.object(time_util.time, "time", frozen):
+                self.assertEqual(getNow(), frozen.value)
+
+    def testGetNowUnsupportedOS(self):
+        with mock.patch.object(time_util.os, "name", "java"):
+            self.assertRaises(ValueError, getNow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix for timing-sensitive test failures in Windows, observed in h5pyd