### PR TITLE
Add a release workflow that publishes to GitHub and PyPI

### DIFF
--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Extract the CHANGELOG.md section for the version being released.
+
+Writes release-notes.md and sets the `has_notes` step output. A missing
+CHANGELOG, or a CHANGELOG with no section for this version, is not an error -
+the release job falls back to GitHub's generated notes. That keeps the release
+pipeline usable before CHANGELOG.md exists (it is still a TBD in the release
+plan) without silently publishing an empty release body.
+
+Recognized heading forms, at any heading level:
+    ## 2.0.0
+    ## v2.0.0
+    ## [2.0.0]
+    ## [2.0.0] - 2026-08-25
+"""
+import os
+import re
+import sys
+from pathlib import Path
+
+CHANGELOG = Path("CHANGELOG.md")
+OUT = Path("release-notes.md")
+
+
+def set_output(name, value):
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as f:
+            f.write(f"{name}={value}\n")
+
+
+def find_section(text, version):
+    """Return the body of the heading matching `version`, or None."""
+    # Escape the version so dots don't act as wildcards.
+    v = re.escape(version)
+    heading = re.compile(
+        rf"^(?P<level>#{{1,6}})\s*\[?v?{v}\]?\s*(?:[-–—]\s*.*)?$",
+        re.MULTILINE,
+    )
+    match = heading.search(text)
+    if not match:
+        return None
+
+    start = match.end()
+    level = len(match.group("level"))
+    # The section ends at the next heading of the same or a shallower level.
+    nxt = re.compile(rf"^#{{1,{level}}}\s", re.MULTILINE)
+    end_match = nxt.search(text, start)
+    end = end_match.start() if end_match else len(text)
+    return text[start:end].strip()
+
+
+def main():
+    version = os.environ.get("VERSION", "").strip()
+    if not version:
+        print("::error::VERSION is not set", file=sys.stderr)
+        return 1
+
+    if not CHANGELOG.is_file():
+        print(f"::warning::{CHANGELOG} not found - release will use generated notes")
+        set_output("has_notes", "false")
+        return 0
+
+    text = CHANGELOG.read_text(encoding="utf-8")
+    body = find_section(text, version)
+    if not body:
+        print(
+            f"::warning::no {CHANGELOG} section found for version {version} "
+            "- release will use generated notes"
+        )
+        set_output("has_notes", "false")
+        return 0
+
+    OUT.write_text(body + "\n", encoding="utf-8")
+    set_output("has_notes", "true")
+    print(f"Extracted {len(body.splitlines())} lines of notes for {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/release_version.py
+++ b/.github/scripts/release_version.py
@@ -7,6 +7,7 @@ Everything else in the release pipeline keys off what this prints, so a tag
 that disagrees with the source tree stops the run before anything is built or
 published.
 """
+import ast
 import os
 import re
 import sys
@@ -47,33 +48,57 @@ def read_pyproject_version():
 
 
 def check_dunder_version(version):
-    """Soft check: warn if h5json exposes a __version__ that disagrees.
+    """Check that h5json.__version__ agrees with pyproject.toml.
 
-    docs/conf.py reads `h5json.__version__`, so once that attribute is
-    restored it becomes a second place the version lives and must agree with
-    pyproject.toml. Warn rather than fail so this does not block a release
-    while the attribute is still missing.
+    docs/conf.py reads `h5json.__version__`, so it is a second place the
+    version is exposed and must not disagree with the SSOT.
+
+    Two forms are accepted. Deriving it from installed distribution metadata
+    (`importlib.metadata.version("h5json")`) is the preferred one: there is
+    only one version in the tree, so it cannot drift, and nothing is checked.
+    A hard-coded literal is a second source of truth, so it is compared and
+    fails on a mismatch. Note the metadata form usually carries a literal
+    fallback for uninstalled source trees - that fallback is deliberately not
+    the declared version and must not be compared against.
     """
     init = Path("src/h5json/__init__.py")
     if not init.is_file():
         return
-    match = re.search(
-        r"^__version__\s*=\s*[\"']([^\"']+)[\"']",
-        init.read_text(encoding="utf-8"),
-        re.MULTILINE,
-    )
-    if not match:
+    try:
+        tree = ast.parse(init.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        fail(f"could not parse {init}: {exc}")
+
+    literals = []
+    derived = False
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "__version__" for t in node.targets
+        ):
+            continue
+        if isinstance(node.value, ast.Call):
+            derived = True
+        elif isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            literals.append(node.value.value)
+
+    if derived:
+        # Single source of truth already - nothing can disagree.
+        return
+    if not literals:
         print(
-            "::warning::src/h5json/__init__.py does not define __version__, but "
-            "docs/conf.py reads h5json.__version__ - the docs build will fail "
-            "until it is restored"
+            f"::warning::{init} does not define __version__, but docs/conf.py "
+            "reads h5json.__version__ - the docs build will fail until it is "
+            "restored"
         )
         return
-    if match.group(1) != version:
-        fail(
-            f"version mismatch: pyproject.toml says {version}, "
-            f"src/h5json/__init__.py __version__ says {match.group(1)}"
-        )
+    for found in literals:
+        if found != version:
+            fail(
+                f"version mismatch: {PYPROJECT} says {version}, "
+                f"{init} __version__ says {found}"
+            )
 
 
 def main():

--- a/.github/scripts/release_version.py
+++ b/.github/scripts/release_version.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Resolve the release version from the repo-local single source of truth.
+
+SSOT: the `version` field of [project] in pyproject.toml.
+
+Everything else in the release pipeline keys off what this prints, so a tag
+that disagrees with the source tree stops the run before anything is built or
+published.
+"""
+import os
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path("pyproject.toml")
+DIST_NAME = "h5json"
+
+# PEP 440 pre-release / dev-release markers.
+PRERELEASE_RE = re.compile(r"(a|b|rc|alpha|beta|dev)\d*$", re.IGNORECASE)
+
+
+def set_output(name, value):
+    out = os.environ.get("GITHUB_OUTPUT")
+    if out:
+        with open(out, "a", encoding="utf-8") as f:
+            f.write(f"{name}={value}\n")
+    print(f"{name}={value}")
+
+
+def fail(msg):
+    print(f"::error::{msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_pyproject_version():
+    if not PYPROJECT.is_file():
+        fail(f"{PYPROJECT} not found")
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    if "version" not in project:
+        fail(
+            f"{PYPROJECT} [project] has no static `version`. If the project has "
+            "moved to a dynamic version, point this script at the new SSOT."
+        )
+    return str(project["version"]).strip()
+
+
+def check_dunder_version(version):
+    """Soft check: warn if h5json exposes a __version__ that disagrees.
+
+    docs/conf.py reads `h5json.__version__`, so once that attribute is
+    restored it becomes a second place the version lives and must agree with
+    pyproject.toml. Warn rather than fail so this does not block a release
+    while the attribute is still missing.
+    """
+    init = Path("src/h5json/__init__.py")
+    if not init.is_file():
+        return
+    match = re.search(
+        r"^__version__\s*=\s*[\"']([^\"']+)[\"']",
+        init.read_text(encoding="utf-8"),
+        re.MULTILINE,
+    )
+    if not match:
+        print(
+            "::warning::src/h5json/__init__.py does not define __version__, but "
+            "docs/conf.py reads h5json.__version__ - the docs build will fail "
+            "until it is restored"
+        )
+        return
+    if match.group(1) != version:
+        fail(
+            f"version mismatch: pyproject.toml says {version}, "
+            f"src/h5json/__init__.py __version__ says {match.group(1)}"
+        )
+
+
+def main():
+    version = read_pyproject_version()
+    check_dunder_version(version)
+
+    tag = f"v{version}"
+    if os.environ.get("EVENT_NAME") == "push":
+        ref = os.environ.get("GITHUB_REF_NAME", "")
+        if ref != tag:
+            fail(
+                f"tag {ref!r} does not match the version in {PYPROJECT} "
+                f"({version}, expected tag {tag!r}). Bump the SSOT and re-tag."
+            )
+
+    set_output("version", version)
+    set_output("tag", tag)
+    set_output("dist_name", DIST_NAME)
+    set_output("prerelease", "true" if PRERELEASE_RE.search(version) else "false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,9 +203,14 @@ jobs:
   # secrets. Requires a one-time publisher config on PyPI; see the repo
   # release docs.
   # ---------------------------------------------------------------------
+  # Runs after github-release rather than alongside it. The two publish to
+  # places with very different undo stories: a GitHub release can be deleted
+  # and recreated, while PyPI permanently burns a version number - a deleted
+  # release cannot be re-uploaded. Ordering it this way means a failure in the
+  # recoverable half stops the irreversible half from happening at all.
   pypi:
     name: Publish to PyPI
-    needs: [version, build]
+    needs: [version, github-release]
     if: needs.version.outputs.dry_run == 'false'
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,263 @@
+name: Release
+
+# Single entry point for cutting a release. Everything downstream (GitHub
+# release, PyPI, conda-forge) is a separate job so the three can fail, be
+# re-run, and be permissioned independently - but they all key off one tag
+# push, so the artifacts can never drift out of sync with each other.
+#
+# To cut a release:
+#   1. Bump the version in pyproject.toml (the SSOT - see the `version` job).
+#   2. Add the matching section to CHANGELOG.md.
+#   3. git tag -a v2.0.0 -m "v2.0.0" && git push origin v2.0.0
+#
+# `workflow_dispatch` runs the same pipeline in dry-run mode (build and
+# validate, publish nothing) so the release can be rehearsed off a branch.
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+[abrc]*[0-9]*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and validate only - publish nothing"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  # Single place to change if the release pipeline moves to a newer Python.
+  BUILD_PYTHON_VERSION: "3.12"
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Resolve and validate the version. Nothing is built or published until
+  # this passes, so a tag that disagrees with the source tree fails fast
+  # and cheaply rather than half-publishing.
+  # ---------------------------------------------------------------------
+  version:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ssot.outputs.version }}
+      tag: ${{ steps.ssot.outputs.tag }}
+      prerelease: ${{ steps.ssot.outputs.prerelease }}
+      has_notes: ${{ steps.notes.outputs.has_notes }}
+      dry_run: ${{ steps.mode.outputs.dry_run }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.BUILD_PYTHON_VERSION }}
+
+      - name: Determine run mode
+        id: mode
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "dry_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "dry_run=${{ inputs.dry_run }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read version from SSOT and validate against tag
+        id: ssot
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: python .github/scripts/release_version.py
+
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        env:
+          VERSION: ${{ steps.ssot.outputs.version }}
+        run: python .github/scripts/release_notes.py
+
+      - name: Upload release notes
+        if: steps.notes.outputs.has_notes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: release-notes.md
+          if-no-files-found: error
+
+      - name: Summary
+        run: |
+          {
+            echo "### Release ${{ steps.ssot.outputs.tag }}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Version | \`${{ steps.ssot.outputs.version }}\` |"
+            echo "| Tag | \`${{ steps.ssot.outputs.tag }}\` |"
+            echo "| Pre-release | \`${{ steps.ssot.outputs.prerelease }}\` |"
+            echo "| Notes from CHANGELOG | \`${{ steps.notes.outputs.has_notes }}\` |"
+            echo "| Dry run | \`${{ steps.mode.outputs.dry_run }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
+  # Build once. The exact same sdist/wheel are attached to the GitHub
+  # release and uploaded to PyPI - never rebuilt per target, so the two
+  # can't disagree.
+  # ---------------------------------------------------------------------
+  build:
+    name: Build distributions
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.BUILD_PYTHON_VERSION }}
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+
+      - name: Check metadata
+        run: python -m twine check --strict dist/*
+
+      - name: Verify built version matches the tag
+        env:
+          EXPECTED: ${{ needs.version.outputs.version }}
+        run: |
+          # Guards against a stale build backend or leftover dist/ contents
+          # silently shipping the wrong version.
+          if ! ls "dist/h5json-${EXPECTED}.tar.gz" >/dev/null 2>&1; then
+            echo "::error::expected dist/h5json-${EXPECTED}.tar.gz, got:"
+            ls -1 dist/
+            exit 1
+          fi
+
+      - name: Smoke test the wheel
+        run: |
+          python -m venv /tmp/smoke
+          /tmp/smoke/bin/pip install --quiet dist/*.whl
+          /tmp/smoke/bin/python -c "import h5json; print('import ok')"
+          /tmp/smoke/bin/h5tojson --help > /dev/null
+          /tmp/smoke/bin/jsontoh5 --help > /dev/null
+          /tmp/smoke/bin/h5jvalidate --help > /dev/null
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  # ---------------------------------------------------------------------
+  # GitHub release. Matches the existing release pattern (annotated tag +
+  # hand-written notes) and additionally attaches the built dists, which
+  # earlier releases did not carry.
+  # ---------------------------------------------------------------------
+  github-release:
+    name: GitHub release
+    needs: [version, build]
+    if: needs.version.outputs.dry_run == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - uses: actions/download-artifact@v4
+        if: needs.version.outputs.has_notes == 'true'
+        with:
+          name: release-notes
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.version.outputs.tag }}
+          PRERELEASE: ${{ needs.version.outputs.prerelease }}
+          HAS_NOTES: ${{ needs.version.outputs.has_notes }}
+        run: |
+          args=(--title "$TAG" --verify-tag)
+          if [ "$HAS_NOTES" = "true" ]; then
+            args+=(--notes-file release-notes.md)
+          else
+            # No CHANGELOG section for this version - fall back to the
+            # commit-derived notes rather than publishing an empty body.
+            args+=(--generate-notes)
+          fi
+          if [ "$PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          gh release create "$TAG" "${args[@]}" dist/*
+
+  # ---------------------------------------------------------------------
+  # PyPI. Uses Trusted Publishing (OIDC) - no long-lived API token in repo
+  # secrets. Requires a one-time publisher config on PyPI; see the repo
+  # release docs.
+  # ---------------------------------------------------------------------
+  pypi:
+    name: Publish to PyPI
+    needs: [version, build]
+    if: needs.version.outputs.dry_run == 'false'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/h5json/${{ needs.version.outputs.version }}
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Trusted Publishing: configure at
+        # https://pypi.org/manage/project/h5json/settings/publishing/
+        #   owner: HDFGroup   repo: hdf5-json
+        #   workflow: release.yml   environment: pypi
+        #
+        # If a token is preferred over OIDC instead, drop `permissions:
+        # id-token` above and set:
+        #   with:
+        #     password: ${{ secrets.PYPI_API_TOKEN }}
+
+  # ---------------------------------------------------------------------
+  # conda-forge.
+  # ---------------------------------------------------------------------
+  conda-forge:
+    name: conda-forge (not yet wired up)
+    needs: [version, github-release]
+    if: needs.version.outputs.dry_run == 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: TODO
+        run: |
+          # TODO(conda-forge): h5json is not on conda-forge yet. Before this
+          # job can do anything real:
+          #
+          #   1. Submit an h5json recipe to conda-forge/staged-recipes. It is
+          #      pure Python, so `noarch: python`, one build, no compilers.
+          #      Entry points: h5tojson, jsontoh5, h5jvalidate.
+          #   2. Get conda-forge/h5json-feedstock created and building.
+          #
+          # After that, the feedstock's own bot opens a version-bump PR
+          # automatically within ~an hour of a PyPI release, so this job may
+          # never need to do anything. Wire it up only if the automatic bump
+          # proves too slow to keep in sync with the coordinated release -
+          # in which case this job should open the feedstock PR directly
+          # (regro autotick-bot style) using a bot token.
+          #
+          # NOTE: h5pyd's conda-forge feedstock cannot add an h5json run
+          # dependency until step 2 lands - its recipe runs `pip check`.
+          echo "conda-forge publishing is not configured yet - see comments in this file."
+          echo "Version that would be published: ${{ needs.version.outputs.version }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "h5py >= 3.10",
     "numpy >= 2.0",
     "jsonschema >=4.4.0",
+    "pytz",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,6 @@ dependencies = [
     "tomli; python_version<'3.11'",
 ]
 
-#dynamic = ["version"]
-
 [project.urls]
 Homepage = "https://support.hdfgroup.org/documentation/hdf5-json/latest/"
 Documentation = "https://support.hdfgroup.org/documentation/hdf5-json/latest/"
@@ -61,9 +59,6 @@ packages = [
 package-data = { "h5json.schema" = ["*.schema.json"] }
 platforms = ["any"]
 zip-safe = false
-
-[tool.setuptools_scm]
-version_file = "src/h5json/_version.py"
 
 # [tool.distutils.bdist_wheel]
 # universal = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,8 @@ version = "2.0.0"
 
 dependencies = [
     "h5py >= 3.10",
-    "numpy >= 2.0; python_version>='3.9'",
+    "numpy >= 2.0",
     "jsonschema >=4.4.0",
-    "tomli; python_version<'3.11'",
 ]
 
 [project.urls]

--- a/src/h5json/__init__.py
+++ b/src/h5json/__init__.py
@@ -17,6 +17,9 @@ This is the h5json package, a mapping between HDF5 objects and JSON
 
 from __future__ import absolute_import
 
+from importlib.metadata import PackageNotFoundError as _PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from .hdf5dtype import getTypeItem
 from .hdf5dtype import getTypeResponse
 from .hdf5dtype import getItemSize
@@ -30,3 +33,9 @@ from .objid import getObjId
 from .objid import isSchema2Id
 from .objid import isRootObjId
 from .hdf5db import Hdf5db
+
+try:
+    __version__ = _pkg_version("h5json")
+except _PackageNotFoundError:
+    # running from a source tree that has not been installed
+    __version__ = "0.0.0.dev0"


### PR DESCRIPTION
Adds a tag-driven workflow that builds, attaches the artifacts to a GitHub release, and then uploads to PyPI (gated on the release succeeding).

Also drops two pieces of dead version config: `[tool.setuptools_scm]` and the commented-out `dynamic` marker. 